### PR TITLE
refactor

### DIFF
--- a/src/components/SearchList/Match.tsx
+++ b/src/components/SearchList/Match.tsx
@@ -1,20 +1,22 @@
 import { useAppSelector } from 'hooks';
 
-function Match(item: { sickNm: string }) {
+type TMatchProps = {
+  sickNm: string;
+};
+
+function Match({ sickNm }: TMatchProps) {
   const searchString = useAppSelector(
     (state) => state.searchString.searchString
   );
-  const { sickNm } = item;
 
-  if (sickNm.indexOf(searchString) !== -1)
+  if (searchString && sickNm.indexOf(searchString) !== -1)
     return (
-      <div>
+      <>
         {sickNm.split(searchString)[0]}
         <mark>{searchString}</mark>
         {sickNm.split(searchString)[1]}
-      </div>
+      </>
     );
-
   return <div>{sickNm}</div>;
 }
 

--- a/src/components/SearchList/index.tsx
+++ b/src/components/SearchList/index.tsx
@@ -1,6 +1,6 @@
-import { MagnifierIcon } from 'assets';
 import { useEffect, useRef, useState } from 'react';
 
+import { MagnifierIcon } from 'assets';
 import { useAppSelector } from 'hooks';
 
 import { IItem } from 'types/search.d';
@@ -8,8 +8,6 @@ import Match from './Match';
 import styles from './search-list.module.scss';
 
 function SearchList() {
-  // 검색 결과 예시
-
   const [isMobile, setIsMobile] = useState<boolean>(true);
 
   const containerRef = useRef<HTMLUListElement>(null);
@@ -26,15 +24,20 @@ function SearchList() {
     ? styles['mobile-list-container']
     : styles['desktop-list-container'];
 
+  const noData = () => {
+    if (filteredList.length !== 0) return null;
+    return <span className={styles['no-data']}>검색어 없음</span>;
+  };
+
   return (
     <ul ref={containerRef} className={containerType}>
       <li className={styles.label}>추천 검색어</li>
-
-      {filteredList?.map((item: IItem, idx: number) => {
-        const key = `$search-list-key-${idx}`;
+      {noData()}
+      {filteredList.map((item: IItem, idx: number) => {
+        const key = `${item.sickCd}-${idx}`;
         return (
           <li key={key} className={styles.item}>
-            <MagnifierIcon />{' '}
+            <MagnifierIcon />
             <span className={styles.name}>
               <Match sickNm={item.sickNm} />
             </span>

--- a/src/components/SearchList/search-list.module.scss
+++ b/src/components/SearchList/search-list.module.scss
@@ -14,6 +14,10 @@
     color: colors.$footer-bg;
   }
 
+  .no-data{
+    padding:8px 0;
+  }
+
   .item {
     display: flex;
     align-items: center;

--- a/src/store/filteredList.ts
+++ b/src/store/filteredList.ts
@@ -1,37 +1,27 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { IItem } from 'types/search.d';
 
 export interface IFilteredListState {
-  item: {
-    sickCd: string;
-    sickNm: string;
-  }[];
+  item: IItem[];
 }
 
 const initialState = {
-  item: [] as {
-    sickCd: string;
-    sickNm: string;
-  }[],
+  item: [] as IItem[],
 };
 
 const filteredListSlice = createSlice({
   name: 'filteredList',
   initialState,
   reducers: {
-    setfilteredList: (
+    setFilteredList: (
       state: IFilteredListState,
-      action: PayloadAction<
-        {
-          sickCd: string;
-          sickNm: string;
-        }[]
-      >
+      action: PayloadAction<IItem[]>
     ) => {
       state.item = action.payload;
     },
   },
 });
 
-export const { setfilteredList } = filteredListSlice.actions;
+export const { setFilteredList } = filteredListSlice.actions;
 
 export default filteredListSlice.reducer;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,8 +1,8 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import logger from 'redux-logger';
 
-import filteredList from './filteredList';
-import searchString from './searchString';
+import filteredList, { setFilteredList } from 'store/filteredList';
+import searchString, { setSearchString } from 'store/searchString';
 
 const rootReducer = combineReducers({ searchString, filteredList });
 
@@ -14,5 +14,5 @@ const store = configureStore({
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
 
-export {};
+export { setFilteredList, setSearchString };
 export default store;

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -12,7 +12,6 @@ interface IGetDissRes {
   };
 }
 
-// ivBH7O1ZQm7WeAqNdvlCx6Qzf62xqkBMD16Unv+hS0GhjqlaxfhF29L5eyrBM9YedmTkgiC6V/o6aaZSrY5cuQ==
 const fetcher = async (searchText: string) => {
   // 배포시 수정 필요 (http://apis.data.go.kr/)
   try {


### PR DESCRIPTION
store/index.ts
- store에서 setSearchString과 setFilteredList를 import하고 한번에 export하여 컴포넌트에서 사용할 때 여러 곳에서 import 되지 않고 'store'에서 모두 import 되도록 수정.

store/filteredList.ts
- 전역으로 선언된 IItem 타입으로 타입들 수정
- filteredlist => filteredList

SearchInput/MobileSearchInput.tsx
- onChange 함수에서 불필요한 callback제거
- Redux의 searchString과 useState의 searchValue의 역할이 중복되기에 searchValue 삭제
- searchValue 삭제에 따라 관련 useEffect 삭제
- data가 없을 시 filterList를 비우도록 else문 추가
- 입력 토글창에 placeholder 삽입
- SearchList 삼항연산자 제거, SearchList 내에서 판별하도록 변경

SearchList/index.tsx
- SearchList의 map에 대한 key값 더 고유하게 변경
- data가 없을시 검색어 없음 출력

SearchList/Match.tsx
- props 타입 선언 분리
- searchString이 없는 경우 return이 되지 않도록 조건 추가
- 불필요한 div 제거